### PR TITLE
chore: update install instructions for Ibis 7.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.ipynb_checkpoints
 *.ddb
 *.parquet
+*.wal

--- a/01 - Getting Started.ipynb
+++ b/01 - Getting Started.ipynb
@@ -24,13 +24,13 @@
     "### `conda` / `mamba`\n",
     "\n",
     "```sh\n",
-    "mamba create -n ibis-tutorial ibis-duckdb=6.1 ipython jupyterlab\n",
+    "mamba create -n ibis-tutorial ibis-duckdb=7 ipython jupyterlab\n",
     "```\n",
     "\n",
     "### `pip`\n",
     "\n",
     "```sh\n",
-    "pip install \"ibis-framework[duckdb]\"==6.1 ipython jupyterlab\n",
+    "pip install \"ibis-framework[duckdb]\"==7 ipython jupyterlab\n",
     "```"
    ]
   },
@@ -835,7 +835,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/01 - Getting Started.ipynb
+++ b/01 - Getting Started.ipynb
@@ -21,17 +21,7 @@
    "id": "97774050-d45e-45e6-972d-224a824f6c76",
    "metadata": {},
    "source": [
-    "### `conda` / `mamba`\n",
-    "\n",
-    "```sh\n",
-    "mamba create -n ibis-tutorial ibis-duckdb=7 ipython jupyterlab\n",
-    "```\n",
-    "\n",
-    "### `pip`\n",
-    "\n",
-    "```sh\n",
-    "pip install \"ibis-framework[duckdb]\"==7 ipython jupyterlab\n",
-    "```"
+    "See the [README](https://github.com/ibis-project/ibis-tutorial#setup) for up-to-date installation instructions!"
    ]
   },
   {
@@ -84,6 +74,14 @@
     "import ibis\n",
     "\n",
     "con = ibis.duckdb.connect(\"palmer_penguins.ddb\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e7a70bb-4890-4d76-b1d6-a7199ec32106",
+   "metadata": {},
+   "source": [
+    "**Note**: when you connect to a DuckDB database file, DuckDB will create a lock-file to prevent data corruption.  If you see a `palmer_penguins.ddb.wal` file, you can safely ignore it. It will get cleaned up automatically."
    ]
   },
   {
@@ -220,6 +218,23 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c4e669a-7a83-4ea7-9dc1-d9da8187b3f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ibis.show_sql(\n",
+    "    penguins.filter(\n",
+    "    [\n",
+    "        penguins.island == \"Torgersen\",\n",
+    "        penguins.species == \"Adelie\",\n",
+    "    ]\n",
+    ")\n",
+    ")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "f656267b-1e19-4dcf-ae90-3e886778c51c",
    "metadata": {},
@@ -309,7 +324,7 @@
    "source": [
     "# Convert the metric units to imperial, and drop the metric columns.\n",
     "# Try this using a `.mutate` and `.drop` call.\n",
-    "penguins_imperial = ..."
+    "penguins_imperial_mutate_drop = ..."
    ]
   },
   {
@@ -321,7 +336,7 @@
    "source": [
     "# Convert the metric units to imperial, and drop the metric columns.\n",
     "# Try this using a single `.select` call.\n",
-    "penguins_imperial = ..."
+    "penguins_imperial_select = ..."
    ]
   },
   {
@@ -350,6 +365,44 @@
    "outputs": [],
    "source": [
     "%load solutions/nb01-ex01-select.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b98fc5b-1872-4cd4-831e-3a9ccc5167cb",
+   "metadata": {},
+   "source": [
+    "### Does it matter which method you choose?\n",
+    "\n",
+    "Yes and no -- there is a difference in the generated SQL of the two approaches:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "39704c4f-2050-42b1-a738-dc01c8246374",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ibis.show_sql(penguins_imperial_mutate_drop)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f6e6c2c8-ecbe-4360-a06c-87870a276b41",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ibis.show_sql(penguins_imperial_select)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a3fc8d1-54ce-41e9-a9b9-86f72c0efd07",
+   "metadata": {},
+   "source": [
+    "But, in practice, this doesn't make a difference.  Any modern SQL execution engine will optimize these two variations to the same set of operations and there will be no measureable performance difference."
    ]
   },
   {

--- a/02 - Memtables, Joins, and Selectors.ipynb
+++ b/02 - Memtables, Joins, and Selectors.ipynb
@@ -146,16 +146,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5cea6364-8265-498f-80f4-bc7bb061e04f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "t2 = ibis.memtable(pat)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "e00a3743-131b-4a47-bafd-5c4f0371bbca",
    "metadata": {},
    "outputs": [],
@@ -463,12 +453,12 @@
    "outputs": [],
    "source": [
     "(\n",
-    "    t1.join(t3, \"name\").rename({\"has_committed\": \"committed_right\"})\n",
-    "    # _ is the table with the relabeled column\n",
+    "    t1.join(t3, \"name\").rename(has_committed=\"committed_right\")\n",
+    "    # _ is the table with the renamed column\n",
     "    .filter(_.has_committed == True)\n",
-    "    # _ is the relabeled, filtered table\n",
+    "    # _ is the relnamed, filtered table\n",
     "    .mutate(commit_percent=_.committed / _.committed.sum() * 100)\n",
-    "    # _ is the relabeled, filtered, mutated table\n",
+    "    # _ is the renamed, filtered, mutated table\n",
     "    .order_by(_.commit_percent.desc())\n",
     ")"
    ]
@@ -631,13 +621,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "c9617c31-5d52-4286-bc56-0b09c4d851ec",
+   "metadata": {},
+   "source": [
+    "The `read_parquet` method returns an Ibis table that points to the to-be-ingested `parquet` file. \n",
+    "\n",
+    "`read_parquet` also registers the table with DuckDB (or another backend), so you can also load the tables like we did for the `penguins` table in the previous notebook."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "41d64c7a-a735-4805-b485-167fd3f6dc9d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "basics = con.tables.imdb_title_basics"
+    "basics = con.tables.imdb_title_basics  # this cell is redundant, just here for demonstration"
    ]
   },
   {
@@ -647,7 +647,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ratings = con.tables.imdb_title_ratings"
+    "ratings = con.tables.imdb_title_ratings  # this cell is redundant, just here for demonstration"
    ]
   },
   {
@@ -717,7 +717,7 @@
    "source": [
     "### Exercise 2\n",
     "\n",
-    "Join `basics` with `ratings` on `tconst`, and select out only the `titleType`, `primaryTitle`, `numVotes`, and `averageRating` columns."
+    "Join `basics` with `ratings` on `tconst`, and select out only the `titleType`, `primaryTitle`, `numVotes`, `averageRating`, and `isAdult`  columns."
    ]
   },
   {
@@ -757,7 +757,7 @@
     "\n",
     "There are two ways you might achieve this:\n",
     "\n",
-    "- Using the `Table.relabel` method\n",
+    "- Using the `Table.rename` method\n",
     "- Or by modifying the `.select` used above to do the relabeling in one step."
    ]
   },
@@ -857,6 +857,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "0348b55d-01df-4397-8621-4228e27c7bcd",
+   "metadata": {},
+   "source": [
+    "Note that for demo purposes, we've preloaded these tables into our Snowflake account.\n",
+    "But if you wanted to add them to your Snowflake account, you could make use of `read_parquet` or similar!"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "57356fc5-d6db-45e5-99a3-b63c68fb331a",
@@ -929,7 +938,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from ibis import selectors as s"
+    "from ibis import selectors as s\n",
+    "from ibis import _"
    ]
   },
   {

--- a/02 - Memtables, Joins, and Selectors.ipynb
+++ b/02 - Memtables, Joins, and Selectors.ipynb
@@ -463,7 +463,7 @@
    "outputs": [],
    "source": [
     "(\n",
-    "    t1.join(t3, \"name\").relabel({\"committed_right\": \"has_committed\"})\n",
+    "    t1.join(t3, \"name\").rename({\"has_committed\": \"committed_right\"})\n",
     "    # _ is the table with the relabeled column\n",
     "    .filter(_.has_committed == True)\n",
     "    # _ is the relabeled, filtered table\n",
@@ -786,7 +786,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%load solutions/nb02-ex03-relabel.py"
+    "%load solutions/nb02-ex03-rename.py"
    ]
   },
   {
@@ -833,16 +833,6 @@
    "outputs": [],
    "source": [
     "%load solutions/nb02-ex04.py"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "97212c8f-2052-4638-92ea-c5d6f874f558",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sol4"
    ]
   },
   {
@@ -1032,14 +1022,31 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2534ef05-127a-47b9-b492-e67bb8ebef91",
+   "id": "f59be874-91af-4c61-961e-d4df4be47288",
    "metadata": {},
    "source": [
     "And just like that, we've computed the z-score across every numeric column! \n",
     "\n",
-    "TODO: explain more\n",
+    "Let's examine that line in a bit more detail, because there is a lot going on there.\n",
     "\n",
-    "It might've been weird to compute the z-score of the `year`, though.  We should remove that.  But that's not hard, because selectors are composable!"
+    "We use `across`, which applies an operation across all columns matching some criteria.\n",
+    "In this example, the criteria is `numeric`, which is a selector that will grab all integer and floating-point columns.\n",
+    "\n",
+    "Within the `across`, the `_` will stand in for each column matched by our selection criteria (`numeric`).\n",
+    "\n",
+    "Wrapping it all up in a `mutate` call means we overwrite the values of the selected columns with the new computed values.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36440125-7aa7-4258-a284-ccca736697a2",
+   "metadata": {},
+   "source": [
+    "It might've been weird to compute the z-score of the `year`, though. The `year` column is typed as an `int64`, which makes sense, but we don't want to treat it as a measurement. \n",
+    "\n",
+    "What we want, is all the `numeric` columns _except_ for `year`.\n",
+    "That's not hard, because selectors are composable!"
    ]
   },
   {
@@ -1149,7 +1156,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/03 - Playing with PyPI.ipynb
+++ b/03 - Playing with PyPI.ipynb
@@ -388,7 +388,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from plotnine import aes, geom_histogram, ggplot, scale_y_log10"
+    "from plotnine import aes, geom_histogram, ggplot, scale_y_log10, geom_bar"
    ]
   },
   {
@@ -834,7 +834,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ We recommend using `conda` or `mamba`, but `pip` works, too!
 #### conda / mamba
 
 ```sh
-mamba create -n ibis-tutorial python ibis-duckdb=6.1 python-duckdb=0.8.1 jupyterlab altair plotnine
+mamba create -n ibis-tutorial python ibis-duckdb=7 python-duckdb=0.8.1 jupyterlab altair plotnine
 ```
 
 #### pip
 
 ```sh
-python -m pip install 'ibis-framework[duckdb]==6.1' duckdb==0.8.1 jupyterlab altair>=5.0.1 plotnine
+python -m pip install 'ibis-framework[duckdb]==7' duckdb==0.8.1 jupyterlab altair>=5.0.1 plotnine
 ```
 
 or

--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ python -m pip install -r requirements.txt
 ### Clone this repository
 
 ```sh
-git clone https://github.com/gforsyth/ibis-tutorial.git
+git clone https://github.com/ibis-project/ibis-tutorial.git
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ibis-framework[duckdb] == 6.1
+ibis-framework[duckdb] == 7
 duckdb == 0.8.1
 jupyterlab
 altair >= 5.0.1

--- a/solutions/nb01-ex01-mutate-drop.py
+++ b/solutions/nb01-ex01-mutate-drop.py
@@ -1,5 +1,5 @@
 # Convert the metric units to imperial, and drop the metric columns.
-penguins_imperial = (
+penguins_imperial_mutate_drop = (
     penguins
     .mutate(
         bill_length_in=penguins.bill_length_mm / 25.4,
@@ -15,4 +15,4 @@ penguins_imperial = (
     )
 )
 
-penguins_imperial
+penguins_imperial_mutate_drop

--- a/solutions/nb01-ex01-select.py
+++ b/solutions/nb01-ex01-select.py
@@ -1,5 +1,5 @@
 # Convert the metric units to imperial, and drop the metric columns.
-penguins_imperial = penguins.select(
+penguins_imperial_select = penguins.select(
     "species",
     "island",
     "sex",
@@ -10,4 +10,4 @@ penguins_imperial = penguins.select(
     body_weight_lb=penguins.body_mass_g / 453.6,
 )
 
-penguins_imperial
+penguins_imperial_select

--- a/solutions/nb01-ex02.py
+++ b/solutions/nb01-ex02.py
@@ -8,7 +8,7 @@ sol2 = (
         ]
     )
     .group_by("island")
-    .body_mass_g.max()
+    .agg(penguins.body_mass_g.max())
 )
 
 sol2

--- a/solutions/nb01-ex03.py
+++ b/solutions/nb01-ex03.py
@@ -2,7 +2,7 @@ sol3 = (
     penguins
     .filter(penguins.sex == "male")
     .group_by(["island", "year"])
-    .body_mass_g.max()
+    .agg(penguins.body_mass_g.max())
 )
 
 sol3

--- a/solutions/nb02-ex03-rename.py
+++ b/solutions/nb02-ex03-rename.py
@@ -2,7 +2,7 @@ sol3 = (
     basics
     .join(ratings, "tconst")
     .select("titleType", "primaryTitle", "numVotes", "averageRating", "isAdult")
-    .relabel("snake_case")
+    .rename("snake_case")
 )
 
 sol3

--- a/solutions/nb02-ex04.py
+++ b/solutions/nb02-ex04.py
@@ -2,7 +2,7 @@ sol4 = (
     basics
     .join(ratings, "tconst")
     .select("titleType", "primaryTitle", "numVotes", "averageRating", "isAdult")
-    .relabel("snake_case")
+    .rename("snake_case")
     .filter(
         [
             _.title_type == "movie",


### PR DESCRIPTION
Initial polish run to update things for changes in 7.x

The main change here is removing `relabel` in favor of `rename`, plus changing version specifiers in the installation instructions.

- chore: update install instructions for Ibis 7.x
- chore: update notebook 2 for ibis 7.x
- chore: add missing plotnine import
