### PR TITLE
chore: add Codespace for tutorial

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+    "image": "mcr.microsoft.com/devcontainers/universal:2",
+    "waitFor": "onCreateCommand",
+    "updateContentCommand": "python3 -m pip install -r requirements.txt",
+    "postCreateCommand": "",
+    "customizations": {
+      "codespaces": {
+        "openFiles": []
+      },
+      "vscode": {
+        "extensions": [
+          "ms-toolsai.jupyter",
+          "ms-python.python"
+        ]
+      }
+    }
+  }


### PR DESCRIPTION
- Merge after #3 

This PR adds the possibility to launch the tutorial in codespace. After running first cell it will install the requirements. 
I ran the tutorial with no problem, except the restart kernel issue at the end of notebook 2. 
There is only a slight esthetics issue with some linting wiggles, but things run no problem 

cc: @gforsyth 
