### PR TITLE
chore: set default interpreter path

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,8 @@
         "notifications.doNotDisturbMode": true,
         "update.showReleaseNotes": false,
         "vsicons.dontShowNewVersionMessage": true,
-        "workbench.welcomePage.walkthroughs.openOnInstall": false
+        "workbench.welcomePage.walkthroughs.openOnInstall": false,
+        "python.defaultInterpreterPath": "/usr/local/bin/python"
       },
       "extensions": ["ms-toolsai.jupyter", "ms-python.python", "quarto.quarto"]
     }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,11 @@
         "update.showReleaseNotes": false,
         "vsicons.dontShowNewVersionMessage": true,
         "workbench.welcomePage.walkthroughs.openOnInstall": false,
-        "python.defaultInterpreterPath": "/usr/local/bin/python"
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "jupyter.kernels.excludePythonEnvironments": [
+          "/usr/bin/python3",
+          "/bin/python3"
+        ]
       },
       "extensions": [
         "ms-toolsai.jupyter",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,12 @@
         "workbench.welcomePage.walkthroughs.openOnInstall": false,
         "python.defaultInterpreterPath": "/usr/local/bin/python"
       },
-      "extensions": ["ms-toolsai.jupyter", "ms-python.python", "quarto.quarto"]
+      "extensions": [
+        "ms-toolsai.jupyter",
+        "ms-python.python",
+        "quarto.quarto",
+        "donjayamanne.vscode-default-python-kernel"
+      ]
     }
   },
   "features": {


### PR DESCRIPTION
Set the default Python interpreter path so people do not have to choose every time they run a notebook