### PR TITLE
chore(data): load imdb data for multi-backend example

### DIFF
--- a/00 - Start Here.qmd
+++ b/00 - Start Here.qmd
@@ -12,12 +12,14 @@ For convenience they're also linked below 👇
 Let's kick things off by loading some PyPI package data into a local PostgreSQL database!
 
 ```{python}
-!duckdb < load.sql
+!duckdb < load_pypi.sql
+!psql < demo/create_imdb.sql
+!duckdb < demo/load_imdb.sql
 ```
 
 And we'll confirm that our PostgreSQL database contains the tables we just loaded.
 
 ```{python}
-!psql <<< '\dt'
+!psql << '\dt'
 !psql < verify.sql
 ```

--- a/03 - Switching Backends.qmd
+++ b/03 - Switching Backends.qmd
@@ -52,7 +52,7 @@ for filename in filenames:
 ```
 
 ```{python}
-!ls
+!ls imdb_smol/
 ```
 
 ### Parquet loading
@@ -62,6 +62,13 @@ in-memory tables. Another common pattern is that you have a few parquet files
 you want to work with. We can load those in to an in-memory DuckDB connection.
 (Note that "in-memory" here just means ephemeral, DuckDB is still very happy to
 operate on as much data as your hard drive can hold)
+
+```{python}
+import ibis
+from ibis import _
+
+ibis.options.interactive = True
+```
 
 ```{python}
 con = ibis.duckdb.connect()
@@ -162,33 +169,58 @@ average rating having received at least 100,000 votes.
 
 ## Expression portability
 
-```{python}
-import os
-
-# this will only work if you have snowflake credentials set up in this environment variable
-# snowflake_con = ibis.connect(os.getenv("SNOWFLAKE_URL"))
-```
-
-Note that for demo purposes, we've preloaded these tables into our Snowflake
-account. But if you wanted to add them to your Snowflake account, you could
-make use of `read_parquet` or similar!
-
-```{python}
-# snowflake_con.list_tables(like="imdb")
-```
+Let's turn off interactive mode for a moment.
 
 ```{python}
 ibis.options.interactive = False
 ```
 
+We've built up an Ibis expression that returns the top 10 highest rated films on
+IMDB for certain criteria.  The data we used is only a 5% sample, but the query
+should work no matter what size the data are.
+
+Now we're going to call a special `unbind` method.
+
 ```{python}
-# expr = sol4.unbind()
+expr = sol4.unbind()
+```
+
+What does `unbind` do?  It takes an Ibis expression that was created using one
+backend (in our case, `DuckDB`) and generalizes it into an "unbound" expression.
+
+Let's look at the `repr` of the unbound expression (this will error if you have
+interactive mode on, that's why we turned it off).
+
+```{python}
+expr
+```
+
+The only visible difference is that we see "UnboundTable" a bunch of times, and
+that's the point.  The _expression_ is independent of the backend that created
+it.
+
+So, if we had a _different_ backend connection, that had the full IMDB ratings
+data loaded into it, could we run our locally developed query against the
+"production" data?
+
+(With caveats that the table names and schema need to match).
+
+Let's find out!
+
+```{python}
+pg_con = ibis.postgres.connect()
 ```
 
 ```{python}
-# expr
+pg_con.list_tables()
 ```
 
+That seems promising.
+
+Now, we can't call `expr.to_pandas()` because the expression isn't _bound_ to a
+backend.  Ibis doesn't know (anymore) where to execute it. Instead, we can use
+the `to_pandas` (or similar) method on the backend connection object itself:
+
 ```{python}
-# snowflake_con.execute(expr).head(10)
+pg_con.to_pandas(expr, limit=10)
 ```

--- a/load_imdb.sql
+++ b/load_imdb.sql
@@ -1,0 +1,6 @@
+ATTACH 'dbname=postgres user=postgres' AS pycon2024 (TYPE POSTGRES);
+
+INSERT INTO pycon2024.imdb_title_basics
+  FROM 'https://storage.googleapis.com/ibis-tutorial-data/imdb/2024-03-22/imdb_title_basics.parquet';
+INSERT INTO pycon2024.imdb_title_ratings
+  FROM 'https://storage.googleapis.com/ibis-tutorial-data/imdb/2024-03-22/imdb_title_ratings.parquet';

--- a/load_pypi.sql
+++ b/load_pypi.sql
@@ -12,8 +12,3 @@ CREATE OR REPLACE TABLE pycon2024.scorecard_checks AS
   FROM 'https://storage.googleapis.com/ibis-tutorial-data/pypi/2024-04-24/scorecard_checks.parquet';
 CREATE OR REPLACE TABLE pycon2024.wheels AS
   FROM 'https://storage.googleapis.com/ibis-tutorial-data/pypi/2024-04-24/wheels.parquet';
-
-CREATE OR REPLACE TABLE pycon2024.imdb_title_basics AS
-  FROM 'https://storage.googleapis.com/ibis-tutorial-data/imdb/2024-03-22/imdb_title_basics.parquet';
-CREATE OR REPLACE TABLE pycon2024.imdb_title_ratings AS
-  FROM 'https://storage.googleapis.com/ibis-tutorial-data/imdb/2024-03-22/imdb_title_ratings.parquet';


### PR DESCRIPTION
Ok, this separates out the data loads in the intro notebook into:

- load pypi data
- use psql to create the imdb tables with the proper casing to work around the duckdb bug
- load imdb data

I also added a few missing imports to the switching backends notebook, and I've added the mic drop along with a bit of prose.